### PR TITLE
Scouting

### DIFF
--- a/BasicSc2Bot.h
+++ b/BasicSc2Bot.h
@@ -56,6 +56,7 @@ private:
 	bool TryScouting(const sc2::Unit&);
 	void CheckScoutStatus();
 	const sc2::Unit *GetGatheringScv();
+	void StartTrainingUnit(const sc2::Unit& barrack_to_train);
 };
 
 #endif


### PR DESCRIPTION
When the game starts, an SCV is picked to walk to the potential enemy base locations.
If it dies or gets close enough and sees the enemy base, it remembers the position.